### PR TITLE
Fix theme persistence

### DIFF
--- a/src/theme-switcher.js
+++ b/src/theme-switcher.js
@@ -22,7 +22,10 @@ document.addEventListener("DOMContentLoaded", () => {
   function toggleTheme() {
     const isDark = !document.documentElement.classList.contains("dark");
     applyTheme(isDark);
-    localStorage.setItem("theme", isDark ? "dark" : "");
+    // Persist the user's explicit theme choice
+    // Store "light" instead of an empty string so page loaders
+    // correctly detect the preference on subsequent visits
+    localStorage.setItem("theme", isDark ? "dark" : "light");
 
     const currentTheme = isDark ? "dark" : "light";
     document.body.classList.add("theme-transition");


### PR DESCRIPTION
## Summary
- store `light` choice rather than an empty string in `theme-switcher.js`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6844c9932ddc83329aab6f58aa60f05d