### PR TITLE
disable automatic translation

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" translate="no">
   <head>
     <script>
       (() => {
@@ -20,6 +20,7 @@
     </script>
 
     <meta charset="UTF-8" />
+    <meta name="google" content="notranslate" />
     <title>Pierre-Louis &ndash; Web Dev</title>
     <style>
       [x-cloak] {

--- a/colophon/index.html
+++ b/colophon/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" translate="no">
   <head>
     <script>
       (() => {
@@ -20,6 +20,7 @@
     </script>
 
     <meta charset="UTF-8" />
+    <meta name="google" content="notranslate" />
     <title>Pierre-Louis &ndash; Web Dev</title>
     <style>
       [x-cloak] {

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" translate="no">
   <head>
     <script>
       (() => {
@@ -20,6 +20,7 @@
     </script>
 
     <meta charset="UTF-8" />
+    <meta name="google" content="notranslate" />
     <title>Pierre-Louis &ndash; Web Dev</title>
     <style>
       [x-cloak] {

--- a/links/index.html
+++ b/links/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" translate="no">
   <head>
     <script>
       (() => {
@@ -20,6 +20,7 @@
     </script>
 
     <meta charset="UTF-8" />
+    <meta name="google" content="notranslate" />
     <title>Pierre-Louis &ndash; Web Dev</title>
     <style>
       [x-cloak] {

--- a/now/index.html
+++ b/now/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" translate="no">
   <head>
     <script>
       (() => {
@@ -20,6 +20,7 @@
     </script>
 
     <meta charset="UTF-8" />
+    <meta name="google" content="notranslate" />
     <title>Pierre-Louis &ndash; Web Dev</title>
     <style>
       [x-cloak] {

--- a/projects/index.html
+++ b/projects/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" translate="no">
   <head>
     <script>
       (() => {
@@ -20,6 +20,7 @@
     </script>
 
     <meta charset="UTF-8" />
+    <meta name="google" content="notranslate" />
     <title>Pierre-Louis &ndash; Web Dev</title>
     <style>
       [x-cloak] {

--- a/uses/index.html
+++ b/uses/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" translate="no">
   <head>
     <script>
       (() => {
@@ -20,6 +20,7 @@
     </script>
 
     <meta charset="UTF-8" />
+    <meta name="google" content="notranslate" />
     <title>Pierre-Louis &ndash; Web Dev</title>
     <style>
       [x-cloak] {


### PR DESCRIPTION
## Summary
- add `translate="no"` attribute on HTML root tags
- insert `notranslate` meta for Google after charset declaration

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6844d7351d348332b8cac4941b04fc35