### PR TITLE
Enable horizontal scroll on Now page carousel

### DIFF
--- a/now/index.html
+++ b/now/index.html
@@ -62,20 +62,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="preload" href="/src/output.css" as="style">
-
     <link rel="stylesheet" href="/src/output.css" />
-    <link
-      rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/OwlCarousel2/2.3.4/assets/owl.carousel.min.css"
-    />
-    <link
-      rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/OwlCarousel2/2.3.4/assets/owl.theme.default.min.css"
-    />
-    <link
-      rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css"
-    />
+
   </head>
 
   <body>
@@ -590,7 +578,7 @@
       <h2 class="section-title center">What am I up to atm?</h2>
       <hr class="divider" />
       <div class="carousel">
-        <div class="owl-carousel owl-theme">
+        <div class="carousel-track">
           <div class="item">
             <img src="pics/architecture1.webp" alt="Picture 1" />
           </div>
@@ -611,11 +599,6 @@
           </div>
           <div class="item">
             <img src="pics/squirrel.webp" alt="Picture 7" />
-          </div>
-        </div>
-        <div class="owl-theme">
-          <div class="owl-controls">
-            <div class="custom-nav owl-nav"></div>
           </div>
         </div>
       </div>
@@ -704,14 +687,6 @@
         <p class="footer-text-right">© 2025</p>
       </div>
     </footer>
-    <script
-      src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"
-      defer
-    ></script>
-    <script
-      src="https://cdnjs.cloudflare.com/ajax/libs/OwlCarousel2/2.3.4/owl.carousel.min.js"
-      defer
-    ></script>
     <script defer src="/src/script.js"></script>
     <script
       defer

--- a/src/output.css
+++ b/src/output.css
@@ -2249,10 +2249,25 @@ hr.divider3 {
 
 .carousel {
   position: relative;
-  overflow: hidden;
 }
 
-.item {
+.carousel-track {
+  display: flex;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch;
+  gap: 10px;
+  scrollbar-width: none;
+}
+
+.carousel-track::-webkit-scrollbar {
+  display: none;
+}
+
+.carousel .item {
+  flex: 0 0 auto;
+  scroll-snap-align: start;
   background: transparent url(/src/assets/loading.webp) no-repeat center center;
   background-size: 100px 100px;
 }

--- a/src/script.js
+++ b/src/script.js
@@ -202,35 +202,22 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 });
 
-// Initialize Owl Carousel on pages that include it
+// Enable natural horizontal scrolling for the now page carousel
 document.addEventListener("DOMContentLoaded", () => {
-  if (typeof window.jQuery === "undefined") return;
-  const $carousel = $(".carousel .owl-carousel");
-  if (!$carousel.length) return;
-  const owl = $carousel.owlCarousel({
-    stagePadding: 50,
-    loop: true,
-    margin: 10,
-    nav: false,
-    responsive: {
-      0: { items: 1 },
-      600: { items: 3 },
-      1000: { items: 5 },
-    },
-  });
+  const track = document.querySelector(".carousel-track");
+  if (!track) return;
 
-  // Allow horizontal wheel scrolling to navigate the carousel
-  $carousel.on("wheel", function (e) {
-    const evt = e.originalEvent;
-    if (Math.abs(evt.deltaX) > Math.abs(evt.deltaY) || e.shiftKey) {
-      e.preventDefault();
-      if (evt.deltaX > 0 || (evt.deltaX === 0 && evt.deltaY > 0)) {
-        owl.trigger("next.owl");
-      } else if (evt.deltaX < 0 || (evt.deltaX === 0 && evt.deltaY < 0)) {
-        owl.trigger("prev.owl");
+  // Translate vertical wheel movements into horizontal scrolling
+  track.addEventListener(
+    "wheel",
+    (e) => {
+      if (Math.abs(e.deltaY) > Math.abs(e.deltaX)) {
+        e.preventDefault();
+        track.scrollLeft += e.deltaY;
       }
-    }
-  });
+    },
+    { passive: false }
+  );
 });
 
 // Lightweight lightbox helpers for the projects page

--- a/src/styles.css
+++ b/src/styles.css
@@ -1100,10 +1100,25 @@ hr.divider3 {
 
 .carousel {
   position: relative;
-  overflow: hidden;
 }
 
-.item {
+.carousel-track {
+  display: flex;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch;
+  gap: 10px;
+  scrollbar-width: none;
+}
+
+.carousel-track::-webkit-scrollbar {
+  display: none;
+}
+
+.carousel .item {
+  flex: 0 0 auto;
+  scroll-snap-align: start;
   background: transparent url(/src/assets/loading.webp) no-repeat center center;
   background-size: 100px 100px;
 }


### PR DESCRIPTION
## Summary
- remove OwlCarousel and jQuery from Now page
- reimplement the carousel markup as a horizontally scrollable track
- style the carousel for scroll snapping
- allow vertical wheel events to scroll horizontally

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6844dc46ad308332a13cb96346850f8b