### PR TITLE
Improve command palette UX

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -114,15 +114,16 @@
           })
         "
             @keydown.escape.window="commandOpen = false"
+            @open-command-palette.window="commandOpen = true"
             @keydown.window="
           if (($event.ctrlKey || $event.metaKey) && $event.key === 'k') {
             $event.preventDefault();
             commandOpen = true;
           } else if (!$event.ctrlKey && !$event.metaKey && !$event.altKey && !$event.shiftKey) {
             const key = $event.key.toLowerCase();
-            if (shortcutMap[key] && !['INPUT', 'TEXTAREA'].includes(document.activeElement.tagName)) {
+            if (shortcutMap[key] && (!['INPUT','TEXTAREA'].includes(document.activeElement.tagName)||commandOpen)) {
               window.location.href = shortcutMap[key];
-            } else if (key === 't' && !['INPUT', 'TEXTAREA'].includes(document.activeElement.tagName)) {
+            } else if (key === 't' && (!['INPUT','TEXTAREA'].includes(document.activeElement.tagName)||commandOpen)) {
               $store.theme.toggle();
             }
           }
@@ -131,7 +132,7 @@
           >
             <button
               @click="commandOpen = true"
-              class="inline-flex items-center justify-between w-full h-8 px-2 text-sm font-medium bg-[var(--box-hover)] rounded-l-xl rounded-r-sm hover:bg-[var(--stroke-secondary)] active:bg-[var(--stroke-lighter)] disabled:opacity-50 disabled:pointer-events-none transition-colors duration-100"
+              class="inline-flex items-center justify-between w-full h-8 px-2 text-sm font-medium bg-[var(--box-hover)] rounded-l-xl rounded-r-sm hover:bg-[var(--stroke-secondary)] active:bg-[var(--stroke-lighter)] disabled:opacity-50 disabled:pointer-events-none"
             >
               <svg
                 class="w-4 h-4 mr-0 sm:mr-2 text-[var(--body)] shrink-0"

--- a/colophon/index.html
+++ b/colophon/index.html
@@ -114,15 +114,16 @@
           })
         "
             @keydown.escape.window="commandOpen = false"
+            @open-command-palette.window="commandOpen = true"
             @keydown.window="
           if (($event.ctrlKey || $event.metaKey) && $event.key === 'k') {
             $event.preventDefault();
             commandOpen = true;
           } else if (!$event.ctrlKey && !$event.metaKey && !$event.altKey && !$event.shiftKey) {
             const key = $event.key.toLowerCase();
-            if (shortcutMap[key] && !['INPUT', 'TEXTAREA'].includes(document.activeElement.tagName)) {
+            if (shortcutMap[key] && (!['INPUT','TEXTAREA'].includes(document.activeElement.tagName)||commandOpen)) {
               window.location.href = shortcutMap[key];
-            } else if (key === 't' && !['INPUT', 'TEXTAREA'].includes(document.activeElement.tagName)) {
+            } else if (key === 't' && (!['INPUT','TEXTAREA'].includes(document.activeElement.tagName)||commandOpen)) {
               $store.theme.toggle();
             }
           }
@@ -131,7 +132,7 @@
           >
             <button
               @click="commandOpen = true"
-              class="inline-flex items-center justify-between w-full h-8 px-2 text-sm font-medium bg-[var(--box-hover)] rounded-l-xl rounded-r-sm hover:bg-[var(--stroke-secondary)] active:bg-[var(--stroke-lighter)] disabled:opacity-50 disabled:pointer-events-none transition-colors duration-100"
+              class="inline-flex items-center justify-between w-full h-8 px-2 text-sm font-medium bg-[var(--box-hover)] rounded-l-xl rounded-r-sm hover:bg-[var(--stroke-secondary)] active:bg-[var(--stroke-lighter)] disabled:opacity-50 disabled:pointer-events-none"
             >
               <svg
                 class="w-4 h-4 mr-0 sm:mr-2 text-[var(--body)] shrink-0"

--- a/index.html
+++ b/index.html
@@ -99,15 +99,16 @@
           })
         "
             @keydown.escape.window="commandOpen = false"
+            @open-command-palette.window="commandOpen = true"
             @keydown.window="
           if (($event.ctrlKey || $event.metaKey) && $event.key === 'k') {
             $event.preventDefault();
             commandOpen = true;
           } else if (!$event.ctrlKey && !$event.metaKey && !$event.altKey && !$event.shiftKey) {
             const key = $event.key.toLowerCase();
-            if (shortcutMap[key] && !['INPUT', 'TEXTAREA'].includes(document.activeElement.tagName)) {
+            if (shortcutMap[key] && (!['INPUT','TEXTAREA'].includes(document.activeElement.tagName)||commandOpen)) {
               window.location.href = shortcutMap[key];
-            } else if (key === 't' && !['INPUT', 'TEXTAREA'].includes(document.activeElement.tagName)) {
+            } else if (key === 't' && (!['INPUT','TEXTAREA'].includes(document.activeElement.tagName)||commandOpen)) {
               $store.theme.toggle();
             }
           }
@@ -116,7 +117,7 @@
           >
             <button
               @click="commandOpen = true"
-              class="inline-flex items-center justify-between w-full h-8 px-2 text-sm font-medium bg-[var(--box-hover)] rounded-l-xl rounded-r-sm hover:bg-[var(--stroke-secondary)] active:bg-[var(--stroke-lighter)] disabled:opacity-50 disabled:pointer-events-none transition-colors duration-100"
+              class="inline-flex items-center justify-between w-full h-8 px-2 text-sm font-medium bg-[var(--box-hover)] rounded-l-xl rounded-r-sm hover:bg-[var(--stroke-secondary)] active:bg-[var(--stroke-lighter)] disabled:opacity-50 disabled:pointer-events-none "
             >
               <svg
                 class="w-4 h-4 mr-0 sm:mr-2 text-[var(--body)] shrink-0"

--- a/links/index.html
+++ b/links/index.html
@@ -114,15 +114,16 @@
           })
         "
             @keydown.escape.window="commandOpen = false"
+            @open-command-palette.window="commandOpen = true"
             @keydown.window="
           if (($event.ctrlKey || $event.metaKey) && $event.key === 'k') {
             $event.preventDefault();
             commandOpen = true;
           } else if (!$event.ctrlKey && !$event.metaKey && !$event.altKey && !$event.shiftKey) {
             const key = $event.key.toLowerCase();
-            if (shortcutMap[key] && !['INPUT', 'TEXTAREA'].includes(document.activeElement.tagName)) {
+            if (shortcutMap[key] && (!['INPUT','TEXTAREA'].includes(document.activeElement.tagName)||commandOpen)) {
               window.location.href = shortcutMap[key];
-            } else if (key === 't' && !['INPUT', 'TEXTAREA'].includes(document.activeElement.tagName)) {
+            } else if (key === 't' && (!['INPUT','TEXTAREA'].includes(document.activeElement.tagName)||commandOpen)) {
               $store.theme.toggle();
             }
           }
@@ -131,7 +132,7 @@
           >
             <button
               @click="commandOpen = true"
-              class="inline-flex items-center justify-between w-full h-8 px-2 text-sm font-medium bg-[var(--box-hover)] rounded-l-xl rounded-r-sm hover:bg-[var(--stroke-secondary)] active:bg-[var(--stroke-lighter)] disabled:opacity-50 disabled:pointer-events-none transition-colors duration-100"
+              class="inline-flex items-center justify-between w-full h-8 px-2 text-sm font-medium bg-[var(--box-hover)] rounded-l-xl rounded-r-sm hover:bg-[var(--stroke-secondary)] active:bg-[var(--stroke-lighter)] disabled:opacity-50 disabled:pointer-events-none"
             >
               <svg
                 class="w-4 h-4 mr-0 sm:mr-2 text-[var(--body)] shrink-0"

--- a/now/index.html
+++ b/now/index.html
@@ -126,15 +126,16 @@
           })
         "
             @keydown.escape.window="commandOpen = false"
+            @open-command-palette.window="commandOpen = true"
             @keydown.window="
           if (($event.ctrlKey || $event.metaKey) && $event.key === 'k') {
             $event.preventDefault();
             commandOpen = true;
           } else if (!$event.ctrlKey && !$event.metaKey && !$event.altKey && !$event.shiftKey) {
             const key = $event.key.toLowerCase();
-            if (shortcutMap[key] && !['INPUT', 'TEXTAREA'].includes(document.activeElement.tagName)) {
+            if (shortcutMap[key] && (!['INPUT','TEXTAREA'].includes(document.activeElement.tagName)||commandOpen)) {
               window.location.href = shortcutMap[key];
-            } else if (key === 't' && !['INPUT', 'TEXTAREA'].includes(document.activeElement.tagName)) {
+            } else if (key === 't' && (!['INPUT','TEXTAREA'].includes(document.activeElement.tagName)||commandOpen)) {
               $store.theme.toggle();
             }
           }
@@ -143,7 +144,7 @@
           >
             <button
               @click="commandOpen = true"
-              class="inline-flex items-center justify-between w-full h-8 px-2 text-sm font-medium bg-[var(--box-hover)] rounded-l-xl rounded-r-sm hover:bg-[var(--stroke-secondary)] active:bg-[var(--stroke-lighter)] disabled:opacity-50 disabled:pointer-events-none transition-colors duration-100"
+              class="inline-flex items-center justify-between w-full h-8 px-2 text-sm font-medium bg-[var(--box-hover)] rounded-l-xl rounded-r-sm hover:bg-[var(--stroke-secondary)] active:bg-[var(--stroke-lighter)] disabled:opacity-50 disabled:pointer-events-none"
             >
               <svg
                 class="w-4 h-4 mr-0 sm:mr-2 text-[var(--body)] shrink-0"

--- a/projects/index.html
+++ b/projects/index.html
@@ -114,15 +114,16 @@
           })
         "
             @keydown.escape.window="commandOpen = false"
+            @open-command-palette.window="commandOpen = true"
             @keydown.window="
           if (($event.ctrlKey || $event.metaKey) && $event.key === 'k') {
             $event.preventDefault();
             commandOpen = true;
           } else if (!$event.ctrlKey && !$event.metaKey && !$event.altKey && !$event.shiftKey) {
             const key = $event.key.toLowerCase();
-            if (shortcutMap[key] && !['INPUT', 'TEXTAREA'].includes(document.activeElement.tagName)) {
+            if (shortcutMap[key] && (!['INPUT','TEXTAREA'].includes(document.activeElement.tagName)||commandOpen)) {
               window.location.href = shortcutMap[key];
-            } else if (key === 't' && !['INPUT', 'TEXTAREA'].includes(document.activeElement.tagName)) {
+            } else if (key === 't' && (!['INPUT','TEXTAREA'].includes(document.activeElement.tagName)||commandOpen)) {
               $store.theme.toggle();
             }
           }
@@ -131,7 +132,7 @@
           >
             <button
               @click="commandOpen = true"
-              class="inline-flex items-center justify-between w-full h-8 px-2 text-sm font-medium bg-[var(--box-hover)] rounded-l-xl rounded-r-sm hover:bg-[var(--stroke-secondary)] active:bg-[var(--stroke-lighter)] disabled:opacity-50 disabled:pointer-events-none transition-colors duration-100"
+              class="inline-flex items-center justify-between w-full h-8 px-2 text-sm font-medium bg-[var(--box-hover)] rounded-l-xl rounded-r-sm hover:bg-[var(--stroke-secondary)] active:bg-[var(--stroke-lighter)] disabled:opacity-50 disabled:pointer-events-none"
             >
               <svg
                 class="w-4 h-4 mr-0 sm:mr-2 text-[var(--body)] shrink-0"

--- a/src/output.css
+++ b/src/output.css
@@ -1117,6 +1117,10 @@ video {
   transition-duration: 150ms;
 }
 
+.duration-75{
+  transition-duration: 75ms;
+}
+
 .ease-in{
   transition-timing-function: cubic-bezier(0.4, 0, 1, 1);
 }
@@ -1491,7 +1495,7 @@ a.inline-icon:not(:hover) .lucide {
   border: 2px solid var(--stroke-lighter);
   background: var(--background);
   line-height: normal;
-  transition: all 400ms ease-in-out;
+  transition: background-color 150ms ease-in-out, border-color 150ms ease-in-out, transform 150ms ease-in-out;
   z-index: 9999;
 }
 
@@ -1779,7 +1783,7 @@ a.project-item:not(:hover) .lucide {
   background: var(--background);
   height: auto;
   line-height: normal;
-  transition: all 400ms ease-in-out;
+  transition: background-color 150ms ease-in-out, border-color 150ms ease-in-out, transform 150ms ease-in-out;
 }
 
 .music p {
@@ -1956,7 +1960,7 @@ a.project-item:not(:hover) .lucide {
   background: var(--background);
   height: auto;
   line-height: normal;
-  transition: all 400ms ease-in-out;
+  transition: background-color 150ms ease-in-out, border-color 150ms ease-in-out, transform 150ms ease-in-out;
 }
 
 .map p {

--- a/src/script.js
+++ b/src/script.js
@@ -262,3 +262,11 @@ document.addEventListener('keydown', (e) => {
     closeLightbox();
   }
 });
+
+// Global keyboard shortcut to toggle the command palette
+document.addEventListener('keydown', (e) => {
+  if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'k') {
+    e.preventDefault();
+    window.dispatchEvent(new CustomEvent('open-command-palette'));
+  }
+});

--- a/src/styles.css
+++ b/src/styles.css
@@ -365,7 +365,7 @@ a.inline-icon:not(:hover) .lucide {
   border: 2px solid var(--stroke-lighter);
   background: var(--background);
   line-height: normal;
-  transition: all 400ms ease-in-out;
+  transition: background-color 150ms ease-in-out, border-color 150ms ease-in-out, transform 150ms ease-in-out;
   z-index: 9999;
 }
 
@@ -652,7 +652,7 @@ a.project-item:not(:hover) .lucide {
   background: var(--background);
   height: auto;
   line-height: normal;
-  transition: all 400ms ease-in-out;
+  transition: background-color 150ms ease-in-out, border-color 150ms ease-in-out, transform 150ms ease-in-out;
 }
 
 .music p {
@@ -817,7 +817,7 @@ a.project-item:not(:hover) .lucide {
   background: var(--background);
   height: auto;
   line-height: normal;
-  transition: all 400ms ease-in-out;
+  transition: background-color 150ms ease-in-out, border-color 150ms ease-in-out, transform 150ms ease-in-out;
 }
 
 .map p {

--- a/uses/index.html
+++ b/uses/index.html
@@ -114,15 +114,16 @@
           })
         "
             @keydown.escape.window="commandOpen = false"
+            @open-command-palette.window="commandOpen = true"
             @keydown.window="
           if (($event.ctrlKey || $event.metaKey) && $event.key === 'k') {
             $event.preventDefault();
             commandOpen = true;
           } else if (!$event.ctrlKey && !$event.metaKey && !$event.altKey && !$event.shiftKey) {
             const key = $event.key.toLowerCase();
-            if (shortcutMap[key] && !['INPUT', 'TEXTAREA'].includes(document.activeElement.tagName)) {
+            if (shortcutMap[key] && (!['INPUT','TEXTAREA'].includes(document.activeElement.tagName)||commandOpen)) {
               window.location.href = shortcutMap[key];
-            } else if (key === 't' && !['INPUT', 'TEXTAREA'].includes(document.activeElement.tagName)) {
+            } else if (key === 't' && (!['INPUT','TEXTAREA'].includes(document.activeElement.tagName)||commandOpen)) {
               $store.theme.toggle();
             }
           }
@@ -131,7 +132,7 @@
           >
             <button
               @click="commandOpen = true"
-              class="inline-flex items-center justify-between w-full h-8 px-2 text-sm font-medium bg-[var(--box-hover)] rounded-l-xl rounded-r-sm hover:bg-[var(--stroke-secondary)] active:bg-[var(--stroke-lighter)] disabled:opacity-50 disabled:pointer-events-none transition-colors duration-100"
+              class="inline-flex items-center justify-between w-full h-8 px-2 text-sm font-medium bg-[var(--box-hover)] rounded-l-xl rounded-r-sm hover:bg-[var(--stroke-secondary)] active:bg-[var(--stroke-lighter)] disabled:opacity-50 disabled:pointer-events-none"
             >
               <svg
                 class="w-4 h-4 mr-0 sm:mr-2 text-[var(--body)] shrink-0"


### PR DESCRIPTION
## Summary
- tweak `Command` pill transition
- emit a global event for Cmd/Ctrl+K
- hook command palette to that event
- speed up the command button hover effect
- allow navigation shortcuts even when the command palette is focused

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6844dcf657348332abf8884069da328a