### PR TITLE
Fix command palette search on uses page

### DIFF
--- a/uses/index.html
+++ b/uses/index.html
@@ -243,7 +243,12 @@
                 isTouchDevice: 'ontouchstart' in window,
                 itemsCache: {},
                 actionMap: window.COMMAND_ACTION_MAP,
-                
+
+                // Optimized empty search check
+                commandSearchIsEmpty() {
+                  return !this.commandSearch || this.commandSearch.length === 0;
+                },
+
                 // Optimized active item check
                 commandItemIsActive(item) {
                   return this.commandItemActive && this.commandItemActive.value === item.value;


### PR DESCRIPTION
## Summary
- restore missing `commandSearchIsEmpty` helper in `/uses` command palette

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68458bfe68048332bc55ac8ca2c18971