### PR TITLE
Fix desktop carousel overflow

### DIFF
--- a/src/output.css
+++ b/src/output.css
@@ -2244,6 +2244,8 @@ hr.divider3 {
 .carousel {
   position: relative;
   margin-bottom: 50px;
+  width: 100%;
+  overflow: hidden;
 }
 
 .carousel-track {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1101,6 +1101,8 @@ hr.divider3 {
 .carousel {
   position: relative;
   margin-bottom: 50px;
+  width: 100%;
+  overflow: hidden;
 }
 
 .carousel-track {


### PR DESCRIPTION
## Summary
- keep the now page image carousel anchored to the viewport

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68459343a2a0833286abe3e11cdb96ff