### PR TITLE
Fix desktop carousel overflow

### DIFF
--- a/src/output.css
+++ b/src/output.css
@@ -2244,6 +2244,8 @@ hr.divider3 {
 .carousel {
   position: relative;
   margin-bottom: 50px;
+  width: 100%;
+  overflow: hidden;
 }
 
 .carousel-track {
@@ -2251,6 +2253,8 @@ hr.divider3 {
   overflow-x: auto;
   overflow-y: hidden;
   scroll-snap-type: x mandatory;
+  scroll-behavior: smooth;
+  overscroll-behavior-x: contain;
   -webkit-overflow-scrolling: touch;
   gap: 10px;
   scrollbar-width: none;

--- a/src/script.js
+++ b/src/script.js
@@ -227,11 +227,16 @@ document.addEventListener("DOMContentLoaded", () => {
       const horizontal = Math.abs(e.deltaX) > Math.abs(e.deltaY) || e.shiftKey;
       if (horizontal) {
         e.preventDefault();
-        track.scrollLeft += e.deltaX || e.deltaY;
+        track.scrollBy({ left: e.deltaX || e.deltaY, behavior: "smooth" });
       }
     },
     { passive: false }
   );
+
+  // Ensure the first slide stays in view when resizing the page
+  window.addEventListener("resize", () => {
+    if (track.scrollLeft !== 0) track.scrollTo({ left: 0 });
+  });
 });
 
 // Lightweight lightbox helpers for the projects page

--- a/src/styles.css
+++ b/src/styles.css
@@ -1101,6 +1101,8 @@ hr.divider3 {
 .carousel {
   position: relative;
   margin-bottom: 50px;
+  width: 100%;
+  overflow: hidden;
 }
 
 .carousel-track {
@@ -1108,6 +1110,8 @@ hr.divider3 {
   overflow-x: auto;
   overflow-y: hidden;
   scroll-snap-type: x mandatory;
+  scroll-behavior: smooth;
+  overscroll-behavior-x: contain;
   -webkit-overflow-scrolling: touch;
   gap: 10px;
   scrollbar-width: none;


### PR DESCRIPTION
## Summary
- keep the now page image carousel anchored to the viewport
- smooth horizontal scrolling and reset first slide on resize

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68459343a2a0833286abe3e11cdb96ff