### PR TITLE
Fix mobile zoom on command palette input

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -438,7 +438,7 @@
                         type="text"
                         x-ref="commandInput"
                         x-model="commandSearch"
-                        class="flex w-full px-2 py-3 text-sm bg-transparent border-0 rounded-md outline-none focus:outline-none focus:ring-0 focus:border-0 placeholder:text-[var(--stroke-secondary)] h-11 disabled:cursor-not-allowed disabled:opacity-50"
+                        class="flex w-full px-2 py-3 text-base sm:text-sm bg-transparent border-0 rounded-md outline-none focus:outline-none focus:ring-0 focus:border-0 placeholder:text-[var(--stroke-secondary)] h-11 disabled:cursor-not-allowed disabled:opacity-50"
                         placeholder="Type a command or search..."
                         autocomplete="off"
                         autocorrect="off"

--- a/colophon/index.html
+++ b/colophon/index.html
@@ -438,7 +438,7 @@
                         type="text"
                         x-ref="commandInput"
                         x-model="commandSearch"
-                        class="flex w-full px-2 py-3 text-sm bg-transparent border-0 rounded-md outline-none focus:outline-none focus:ring-0 focus:border-0 placeholder:text-[var(--stroke-secondary)] h-11 disabled:cursor-not-allowed disabled:opacity-50"
+                        class="flex w-full px-2 py-3 text-base sm:text-sm bg-transparent border-0 rounded-md outline-none focus:outline-none focus:ring-0 focus:border-0 placeholder:text-[var(--stroke-secondary)] h-11 disabled:cursor-not-allowed disabled:opacity-50"
                         placeholder="Type a command or search..."
                         autocomplete="off"
                         autocorrect="off"

--- a/index.html
+++ b/index.html
@@ -423,7 +423,7 @@
                         type="text"
                         x-ref="commandInput"
                         x-model="commandSearch"
-                        class="flex w-full px-2 py-3 text-sm bg-transparent border-0 rounded-md outline-none focus:outline-none focus:ring-0 focus:border-0 placeholder:text-[var(--stroke-secondary)] h-11 disabled:cursor-not-allowed disabled:opacity-50"
+                        class="flex w-full px-2 py-3 text-base sm:text-sm bg-transparent border-0 rounded-md outline-none focus:outline-none focus:ring-0 focus:border-0 placeholder:text-[var(--stroke-secondary)] h-11 disabled:cursor-not-allowed disabled:opacity-50"
                         placeholder="Type a command or search..."
                         autocomplete="off"
                         autocorrect="off"

--- a/links/index.html
+++ b/links/index.html
@@ -438,7 +438,7 @@
                         type="text"
                         x-ref="commandInput"
                         x-model="commandSearch"
-                        class="flex w-full px-2 py-3 text-sm bg-transparent border-0 rounded-md outline-none focus:outline-none focus:ring-0 focus:border-0 placeholder:text-[var(--stroke-secondary)] h-11 disabled:cursor-not-allowed disabled:opacity-50"
+                        class="flex w-full px-2 py-3 text-base sm:text-sm bg-transparent border-0 rounded-md outline-none focus:outline-none focus:ring-0 focus:border-0 placeholder:text-[var(--stroke-secondary)] h-11 disabled:cursor-not-allowed disabled:opacity-50"
                         placeholder="Type a command or search..."
                         autocomplete="off"
                         autocorrect="off"

--- a/now/index.html
+++ b/now/index.html
@@ -438,7 +438,7 @@
                         type="text"
                         x-ref="commandInput"
                         x-model="commandSearch"
-                        class="flex w-full px-2 py-3 text-sm bg-transparent border-0 rounded-md outline-none focus:outline-none focus:ring-0 focus:border-0 placeholder:text-[var(--stroke-secondary)] h-11 disabled:cursor-not-allowed disabled:opacity-50"
+                        class="flex w-full px-2 py-3 text-base sm:text-sm bg-transparent border-0 rounded-md outline-none focus:outline-none focus:ring-0 focus:border-0 placeholder:text-[var(--stroke-secondary)] h-11 disabled:cursor-not-allowed disabled:opacity-50"
                         placeholder="Type a command or search..."
                         autocomplete="off"
                         autocorrect="off"

--- a/projects/index.html
+++ b/projects/index.html
@@ -438,7 +438,7 @@
                         type="text"
                         x-ref="commandInput"
                         x-model="commandSearch"
-                        class="flex w-full px-2 py-3 text-sm bg-transparent border-0 rounded-md outline-none focus:outline-none focus:ring-0 focus:border-0 placeholder:text-[var(--stroke-secondary)] h-11 disabled:cursor-not-allowed disabled:opacity-50"
+                        class="flex w-full px-2 py-3 text-base sm:text-sm bg-transparent border-0 rounded-md outline-none focus:outline-none focus:ring-0 focus:border-0 placeholder:text-[var(--stroke-secondary)] h-11 disabled:cursor-not-allowed disabled:opacity-50"
                         placeholder="Type a command or search..."
                         autocomplete="off"
                         autocorrect="off"

--- a/src/output.css
+++ b/src/output.css
@@ -1009,6 +1009,11 @@ video {
   text-align: left;
 }
 
+.text-base{
+  font-size: 1rem;
+  line-height: 1.5rem;
+}
+
 .text-sm{
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -3500,6 +3505,11 @@ hr.divider3 {
 
   .sm\:pb-0{
     padding-bottom: 0px;
+  }
+
+  .sm\:text-sm{
+    font-size: 0.875rem;
+    line-height: 1.25rem;
   }
 }
 

--- a/uses/index.html
+++ b/uses/index.html
@@ -438,7 +438,7 @@
                         type="text"
                         x-ref="commandInput"
                         x-model="commandSearch"
-                        class="flex w-full px-2 py-3 text-sm bg-transparent border-0 rounded-md outline-none focus:outline-none focus:ring-0 focus:border-0 placeholder:text-[var(--stroke-secondary)] h-11 disabled:cursor-not-allowed disabled:opacity-50"
+                        class="flex w-full px-2 py-3 text-base sm:text-sm bg-transparent border-0 rounded-md outline-none focus:outline-none focus:ring-0 focus:border-0 placeholder:text-[var(--stroke-secondary)] h-11 disabled:cursor-not-allowed disabled:opacity-50"
                         placeholder="Type a command or search..."
                         autocomplete="off"
                         autocorrect="off"


### PR DESCRIPTION
## Summary
- prevent iOS zoom by using larger base font on command palette inputs
- rebuild Tailwind CSS

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68459745e3688332b39f904206f55d4b