### PR TITLE
Enhance carousel drag scrolling

### DIFF
--- a/src/output.css
+++ b/src/output.css
@@ -2244,6 +2244,8 @@ hr.divider3 {
 .carousel {
   position: relative;
   margin-bottom: 50px;
+  width: 100%;
+  overflow: hidden;
 }
 
 .carousel-track {
@@ -2251,9 +2253,19 @@ hr.divider3 {
   overflow-x: auto;
   overflow-y: hidden;
   scroll-snap-type: x mandatory;
+  scroll-behavior: smooth;
+  overscroll-behavior-x: contain;
   -webkit-overflow-scrolling: touch;
   gap: 10px;
   scrollbar-width: none;
+  cursor: grab;
+  -webkit-user-select: none;
+     -moz-user-select: none;
+          user-select: none;
+}
+
+.carousel-track.dragging {
+  cursor: grabbing;
 }
 
 .carousel-track::-webkit-scrollbar {
@@ -2268,6 +2280,9 @@ hr.divider3 {
   width: 200px;
   height: 200px;
   overflow: hidden;
+  -webkit-user-select: none;
+     -moz-user-select: none;
+          user-select: none;
 }
 
 .carousel .item img {

--- a/src/script.js
+++ b/src/script.js
@@ -219,8 +219,33 @@ document.addEventListener("DOMContentLoaded", () => {
   const track = document.querySelector(".carousel-track");
   if (!track) return;
 
+  let dragging = false;
+  let startX = 0;
+  let startScroll = 0;
+
+  const endDrag = () => {
+    dragging = false;
+    track.classList.remove("dragging");
+  };
+
+  track.addEventListener("pointerdown", (e) => {
+    dragging = true;
+    startX = e.clientX;
+    startScroll = track.scrollLeft;
+    track.classList.add("dragging");
+    track.setPointerCapture(e.pointerId);
+  });
+
+  track.addEventListener("pointermove", (e) => {
+    if (!dragging) return;
+    const dx = e.clientX - startX;
+    track.scrollLeft = startScroll - dx;
+  });
+
+  track.addEventListener("pointerup", endDrag);
+  track.addEventListener("pointercancel", endDrag);
+
   // Allow horizontal wheel or Shift + wheel to control the carousel
-  // while letting vertical scrolling move the page
   track.addEventListener(
     "wheel",
     (e) => {
@@ -232,6 +257,11 @@ document.addEventListener("DOMContentLoaded", () => {
     },
     { passive: false }
   );
+
+  // Ensure the first slide stays in view when resizing the page
+  window.addEventListener("resize", () => {
+    if (track.scrollLeft !== 0) track.scrollTo({ left: 0 });
+  });
 });
 
 // Lightweight lightbox helpers for the projects page

--- a/src/styles.css
+++ b/src/styles.css
@@ -873,7 +873,9 @@ a.project-item:not(:hover) .lucide {
   right: 1px;
   margin: 0.75rem;
   z-index: 10;
-  user-select: none;
+  -webkit-user-select: none;
+     -moz-user-select: none;
+          user-select: none;
   border-radius: 10px;
   border: 2px solid var(--stroke-lighter);
   background-color: var(--background);
@@ -1116,7 +1118,9 @@ hr.divider3 {
   gap: 10px;
   scrollbar-width: none;
   cursor: grab;
-  user-select: none;
+  -webkit-user-select: none;
+     -moz-user-select: none;
+          user-select: none;
 }
 
 .carousel-track.dragging {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1101,6 +1101,8 @@ hr.divider3 {
 .carousel {
   position: relative;
   margin-bottom: 50px;
+  width: 100%;
+  overflow: hidden;
 }
 
 .carousel-track {
@@ -1108,9 +1110,17 @@ hr.divider3 {
   overflow-x: auto;
   overflow-y: hidden;
   scroll-snap-type: x mandatory;
+  scroll-behavior: smooth;
+  overscroll-behavior-x: contain;
   -webkit-overflow-scrolling: touch;
   gap: 10px;
   scrollbar-width: none;
+  cursor: grab;
+  user-select: none;
+}
+
+.carousel-track.dragging {
+  cursor: grabbing;
 }
 
 .carousel-track::-webkit-scrollbar {
@@ -1125,6 +1135,7 @@ hr.divider3 {
   width: 200px;
   height: 200px;
   overflow: hidden;
+  user-select: none;
 }
 
 .carousel .item img {


### PR DESCRIPTION
## Summary
- let the now page carousel support pointer dragging
- prevent text selection and show a grabbing cursor while dragging
- smooth horizontal scrolling without sluggish transitions

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68459343a2a0833286abe3e11cdb96ff