### PR TITLE
Fix mobile layout on uses page

### DIFF
--- a/src/output.css
+++ b/src/output.css
@@ -3155,9 +3155,17 @@ hr.divider3 {
 /* Responsive design */
 
 @media screen and (max-width: 768px) {
+  .arsenal-sections {
+    flex-direction: column;
+    gap: 2rem;
+    max-width: none;
+    margin: 2rem auto;
+  }
+
   .arsenal-category {
     margin-left: 1.25rem;
     margin-right: 1.25rem;
+    max-width: none;
     width: calc(100% - 2.5rem);
   }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -1993,9 +1993,16 @@ hr.divider3 {
 
 /* Responsive design */
 @media screen and (max-width: 768px) {
+  .arsenal-sections {
+    flex-direction: column;
+    gap: 2rem;
+    max-width: none;
+    margin: 2rem auto;
+  }
   .arsenal-category {
     margin-left: 1.25rem;
     margin-right: 1.25rem;
+    max-width: none;
     width: calc(100% - 2.5rem);
   }
 


### PR DESCRIPTION
## Summary
- improve responsiveness of `uses` page by stacking categories vertically on small screens

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6845f566262c83329c08e4bcf1b66ffd