### PR TITLE
Fix mobile layout on uses page

### DIFF
--- a/src/output.css
+++ b/src/output.css
@@ -3158,6 +3158,7 @@ hr.divider3 {
   .arsenal-category {
     margin-left: 1.25rem;
     margin-right: 1.25rem;
+    max-width: none;
     width: calc(100% - 2.5rem);
   }
 
@@ -3216,6 +3217,13 @@ hr.divider3 {
   .project-thumbnails,
   .project-meta {
     padding: 0 1.25rem;
+  }
+
+  .arsenal-sections {
+    flex-direction: column;
+    gap: 2rem;
+    max-width: none;
+    margin: 2rem auto;
   }
 
   footer p.links {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1996,6 +1996,7 @@ hr.divider3 {
   .arsenal-category {
     margin-left: 1.25rem;
     margin-right: 1.25rem;
+    max-width: none;
     width: calc(100% - 2.5rem);
   }
 
@@ -2054,6 +2055,13 @@ hr.divider3 {
   .project-thumbnails,
   .project-meta {
     padding: 0 1.25rem;
+  }
+
+  .arsenal-sections {
+    flex-direction: column;
+    gap: 2rem;
+    max-width: none;
+    margin: 2rem auto;
   }
 
   footer p.links {


### PR DESCRIPTION
## Summary
- improve responsiveness of `uses` page by stacking categories vertically on small screens
- move `.arsenal-sections` style to global 768px media query for consistent layout

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6845f566262c83329c08e4bcf1b66ffd