### PR TITLE
Fix responsive carousel on now page

### DIFF
--- a/src/output.css
+++ b/src/output.css
@@ -2277,10 +2277,12 @@ hr.divider3 {
   -webkit-user-select: none;
   -moz-user-select: none;
   user-select: none;
+  touch-action: pan-y;
 }
 
 .carousel-track.dragging {
   cursor: grabbing;
+  cursor: -webkit-grabbing;
 }
 
 .carousel-track::-webkit-scrollbar {
@@ -2292,8 +2294,8 @@ hr.divider3 {
   scroll-snap-align: start;
   background: transparent url(/src/assets/loading.webp) no-repeat center center;
   background-size: 100px 100px;
-  width: 200px;
-  height: 200px;
+  width: clamp(180px, 70vw, 250px);
+  height: clamp(180px, 70vw, 250px);
   overflow: hidden;
   -webkit-user-select: none;
      -moz-user-select: none;

--- a/src/styles.css
+++ b/src/styles.css
@@ -1130,10 +1130,12 @@ hr.divider3 {
   -webkit-user-select: none;
   -moz-user-select: none;
   user-select: none;
+  touch-action: pan-y;
 }
 
 .carousel-track.dragging {
   cursor: grabbing;
+  cursor: -webkit-grabbing;
 }
 
 .carousel-track::-webkit-scrollbar {
@@ -1145,8 +1147,8 @@ hr.divider3 {
   scroll-snap-align: start;
   background: transparent url(/src/assets/loading.webp) no-repeat center center;
   background-size: 100px 100px;
-  width: 200px;
-  height: 200px;
+  width: clamp(180px, 70vw, 250px);
+  height: clamp(180px, 70vw, 250px);
   overflow: hidden;
   user-select: none;
 }


### PR DESCRIPTION
## Summary
- improve carousel drag logic with pointer events for desktop and mobile
- add infinite-loop helper so carousel always covers screen width
- allow trackpad scrolling and shift+wheel dragging
- tweak carousel styles for responsive image sizes
- rebuild CSS with updated Tailwind output

## Testing
- `npm run build` *(fails: tailwind binary missing)*
- `node node_modules/tailwindcss/lib/cli.js -i ./src/styles.css -o ./src/output.css`

------
https://chatgpt.com/codex/tasks/task_e_6872778f3fbc83329adf6891180afdbd