### PR TITLE
Add posts build workflow

### DIFF
--- a/.github/workflows/build-posts.yml
+++ b/.github/workflows/build-posts.yml
@@ -1,0 +1,38 @@
+name: Build Posts
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build-posts:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build posts
+        run: npm run build:posts
+
+      - name: Commit and push generated posts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config --global user.name 'GitHub Actions'
+          git config --global user.email 'actions@github.com'
+          git add posts/articles posts/notes src/assets || true
+          git commit -m 'Build posts' || echo "No changes to commit"
+          git push

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
     "tailwindcss": "^3.4.14"
   },
   "scripts": {
-    "build": "npx tailwindcss -i ./src/styles.css -o ./src/output.css",
+    "build": "node node_modules/tailwindcss/lib/cli.js -i ./src/styles.css -o ./src/output.css",
+    "build:posts": "node scripts/build-posts.js",
     "dev": "nodemon --watch ./src/styles.css --exec \"npx tailwindcss -i ./src/styles.css -o ./src/output.css\""
   }
 }

--- a/scripts/build-posts.js
+++ b/scripts/build-posts.js
@@ -1,0 +1,39 @@
+const fs = require('fs/promises');
+const path = require('path');
+
+async function build() {
+  const tplPath = path.resolve(__dirname, '../template/index.html');
+  let tpl;
+  try {
+    tpl = await fs.readFile(tplPath, 'utf8');
+  } catch (err) {
+    console.error('Template missing:', tplPath);
+    return;
+  }
+
+  const postRoots = ['articles', 'notes'].map((p) => path.resolve(__dirname, '../posts', p));
+  for (const dir of postRoots) {
+    try {
+      const entries = await fs.readdir(dir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (!entry.isDirectory()) continue;
+        const folder = path.join(dir, entry.name);
+        const mdPath = path.join(folder, 'index.md');
+        try {
+          const md = await fs.readFile(mdPath, 'utf8');
+          const html = tpl.replace('{{ content }}', md);
+          await fs.writeFile(path.join(folder, 'index.html'), html);
+        } catch {
+          // ignore folders without markdown
+        }
+      }
+    } catch {
+      // directory may not exist
+    }
+  }
+}
+
+build().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/template/index.html
+++ b/template/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>{{ title }}</title>
+  <link rel="stylesheet" href="/src/output.css">
+</head>
+<body>
+{{ content }}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `build-posts.yml` workflow to automate building posts
- add basic posts build script and template
- fix Tailwind build script

## Testing
- `npm run build`
- `npm run build:posts`


------
https://chatgpt.com/codex/tasks/task_e_687ce6f451f083329cea5f5ac60da290