### PR TITLE
fix: add canonical URL and redirect

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,6 +1,16 @@
 # Enable mod_rewrite
 RewriteEngine On
 
+# Redirect `/index.html` to the canonical root URL
+RewriteCond %{THE_REQUEST} /index\.html [NC]
+RewriteRule ^(.*/)?index\.html$ /$1 [R=301,L]
+
+# Enforce HTTPS and non-www hostname
+RewriteCond %{HTTP_HOST} ^www\.(.+)$ [NC]
+RewriteRule ^ https://%1%{REQUEST_URI} [R=301,L]
+RewriteCond %{HTTPS} off
+RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
+
 # (Optional) If your site lives at the domain root, this can help some setups.
 # RewriteBase /
 

--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
     <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5" />
     <meta name="msapplication-TileColor" content="#da532c" />
     <meta name="theme-color" content="#ffffff" />
-
+    <link rel="canonical" href="https://pierrelouis.net/" />
     <link rel="preload" href="/src/output-v132.css" as="style" />
 
     <link rel="stylesheet" href="/src/output-v132.css" />


### PR DESCRIPTION
## Summary
- redirect /index.html to root and enforce HTTPS/non-www via .htaccess
- add canonical link to homepage

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6891e127e6c08332a031ff025ac1720f