### PR TITLE
Sync browser chrome with theme

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -3,16 +3,23 @@
   <head>
     <script>
       (() => {
+        const themeColors = {
+          light: "#faf9f9",
+          dark: "#0f0f0f",
+        };
+        window.__PL_THEME_COLORS = themeColors;
+
         const theme = localStorage.theme || "system";
-        if (
-          theme === "dark" ||
-          (theme === "system" &&
-            window.matchMedia("(prefers-color-scheme: dark)").matches)
-        ) {
-          document.documentElement.classList.add("dark");
-        } else {
-          document.documentElement.classList.remove("dark");
-        }
+        const prefersDark = window
+          .matchMedia("(prefers-color-scheme: dark)")
+          .matches;
+        const useDark =
+          theme === "dark" || (theme === "system" && prefersDark);
+
+        document.documentElement.classList.toggle("dark", useDark);
+        window.__PL_INITIAL_THEME = useDark ? "dark" : "light";
+        window.__PL_ACTIVE_THEME_COLOR =
+          themeColors[useDark ? "dark" : "light"];
       })();
     </script>
     <script>
@@ -58,7 +65,59 @@
     <link rel="manifest" href="/site.webmanifest" />
     <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5" />
     <meta name="msapplication-TileColor" content="#da532c" />
-    <meta name="theme-color" content="#ffffff" />
+    <meta
+      name="theme-color"
+      content="#faf9f9"
+      media="(prefers-color-scheme: light)"
+      data-theme-control="color"
+    />
+    <meta
+      name="theme-color"
+      content="#0f0f0f"
+      media="(prefers-color-scheme: dark)"
+      data-theme-control="color"
+    />
+    <meta name="theme-color" content="#faf9f9" data-theme-control="color" />
+    <meta
+      name="msapplication-navbutton-color"
+      content="#faf9f9"
+      data-theme-control="color"
+    />
+    <meta
+      name="apple-mobile-web-app-status-bar-style"
+      content="default"
+      data-theme-control="status"
+    />
+    <script>
+      (() => {
+        const themeColors = window.__PL_THEME_COLORS || {
+          light: "#faf9f9",
+          dark: "#0f0f0f",
+        };
+        const mode =
+          window.__PL_INITIAL_THEME ||
+          (document.documentElement.classList.contains("dark")
+            ? "dark"
+            : "light");
+        const color = themeColors[mode] || themeColors.light;
+
+        document
+          .querySelectorAll('meta[data-theme-control="color"]')
+          .forEach((meta) => {
+            meta.setAttribute("content", color);
+          });
+
+        const statusMeta = document.querySelector(
+          'meta[data-theme-control="status"]'
+        );
+        if (statusMeta) {
+          statusMeta.setAttribute("content", mode === "dark" ? "black" : "default");
+        }
+
+        window.__PL_ACTIVE_THEME_COLOR = color;
+        window.__PL_CURRENT_THEME_APPEARANCE = mode;
+      })();
+    </script>
     <link rel="preload" href="/src/output-v168.css" as="style" />
 
     <link rel="stylesheet" href="/src/output-v168.css" />

--- a/bookmarks/index.html
+++ b/bookmarks/index.html
@@ -3,16 +3,23 @@
   <head>
     <script>
       (() => {
+        const themeColors = {
+          light: "#faf9f9",
+          dark: "#0f0f0f",
+        };
+        window.__PL_THEME_COLORS = themeColors;
+
         const theme = localStorage.theme || "system";
-        if (
-          theme === "dark" ||
-          (theme === "system" &&
-            window.matchMedia("(prefers-color-scheme: dark)").matches)
-        ) {
-          document.documentElement.classList.add("dark");
-        } else {
-          document.documentElement.classList.remove("dark");
-        }
+        const prefersDark = window
+          .matchMedia("(prefers-color-scheme: dark)")
+          .matches;
+        const useDark =
+          theme === "dark" || (theme === "system" && prefersDark);
+
+        document.documentElement.classList.toggle("dark", useDark);
+        window.__PL_INITIAL_THEME = useDark ? "dark" : "light";
+        window.__PL_ACTIVE_THEME_COLOR =
+          themeColors[useDark ? "dark" : "light"];
       })();
     </script>
     <script>
@@ -58,7 +65,59 @@
     <link rel="manifest" href="/site.webmanifest" />
     <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5" />
     <meta name="msapplication-TileColor" content="#da532c" />
-    <meta name="theme-color" content="#ffffff" />
+    <meta
+      name="theme-color"
+      content="#faf9f9"
+      media="(prefers-color-scheme: light)"
+      data-theme-control="color"
+    />
+    <meta
+      name="theme-color"
+      content="#0f0f0f"
+      media="(prefers-color-scheme: dark)"
+      data-theme-control="color"
+    />
+    <meta name="theme-color" content="#faf9f9" data-theme-control="color" />
+    <meta
+      name="msapplication-navbutton-color"
+      content="#faf9f9"
+      data-theme-control="color"
+    />
+    <meta
+      name="apple-mobile-web-app-status-bar-style"
+      content="default"
+      data-theme-control="status"
+    />
+    <script>
+      (() => {
+        const themeColors = window.__PL_THEME_COLORS || {
+          light: "#faf9f9",
+          dark: "#0f0f0f",
+        };
+        const mode =
+          window.__PL_INITIAL_THEME ||
+          (document.documentElement.classList.contains("dark")
+            ? "dark"
+            : "light");
+        const color = themeColors[mode] || themeColors.light;
+
+        document
+          .querySelectorAll('meta[data-theme-control="color"]')
+          .forEach((meta) => {
+            meta.setAttribute("content", color);
+          });
+
+        const statusMeta = document.querySelector(
+          'meta[data-theme-control="status"]'
+        );
+        if (statusMeta) {
+          statusMeta.setAttribute("content", mode === "dark" ? "black" : "default");
+        }
+
+        window.__PL_ACTIVE_THEME_COLOR = color;
+        window.__PL_CURRENT_THEME_APPEARANCE = mode;
+      })();
+    </script>
     <link rel="preload" href="/src/output-v168.css" as="style" />
 
     <link rel="stylesheet" href="/src/output-v168.css" />

--- a/colophon/index.html
+++ b/colophon/index.html
@@ -3,16 +3,23 @@
   <head>
     <script>
       (() => {
+        const themeColors = {
+          light: "#faf9f9",
+          dark: "#0f0f0f",
+        };
+        window.__PL_THEME_COLORS = themeColors;
+
         const theme = localStorage.theme || "system";
-        if (
-          theme === "dark" ||
-          (theme === "system" &&
-            window.matchMedia("(prefers-color-scheme: dark)").matches)
-        ) {
-          document.documentElement.classList.add("dark");
-        } else {
-          document.documentElement.classList.remove("dark");
-        }
+        const prefersDark = window
+          .matchMedia("(prefers-color-scheme: dark)")
+          .matches;
+        const useDark =
+          theme === "dark" || (theme === "system" && prefersDark);
+
+        document.documentElement.classList.toggle("dark", useDark);
+        window.__PL_INITIAL_THEME = useDark ? "dark" : "light";
+        window.__PL_ACTIVE_THEME_COLOR =
+          themeColors[useDark ? "dark" : "light"];
       })();
     </script>
     <script>
@@ -58,7 +65,59 @@
     <link rel="manifest" href="/site.webmanifest" />
     <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5" />
     <meta name="msapplication-TileColor" content="#da532c" />
-    <meta name="theme-color" content="#ffffff" />
+    <meta
+      name="theme-color"
+      content="#faf9f9"
+      media="(prefers-color-scheme: light)"
+      data-theme-control="color"
+    />
+    <meta
+      name="theme-color"
+      content="#0f0f0f"
+      media="(prefers-color-scheme: dark)"
+      data-theme-control="color"
+    />
+    <meta name="theme-color" content="#faf9f9" data-theme-control="color" />
+    <meta
+      name="msapplication-navbutton-color"
+      content="#faf9f9"
+      data-theme-control="color"
+    />
+    <meta
+      name="apple-mobile-web-app-status-bar-style"
+      content="default"
+      data-theme-control="status"
+    />
+    <script>
+      (() => {
+        const themeColors = window.__PL_THEME_COLORS || {
+          light: "#faf9f9",
+          dark: "#0f0f0f",
+        };
+        const mode =
+          window.__PL_INITIAL_THEME ||
+          (document.documentElement.classList.contains("dark")
+            ? "dark"
+            : "light");
+        const color = themeColors[mode] || themeColors.light;
+
+        document
+          .querySelectorAll('meta[data-theme-control="color"]')
+          .forEach((meta) => {
+            meta.setAttribute("content", color);
+          });
+
+        const statusMeta = document.querySelector(
+          'meta[data-theme-control="status"]'
+        );
+        if (statusMeta) {
+          statusMeta.setAttribute("content", mode === "dark" ? "black" : "default");
+        }
+
+        window.__PL_ACTIVE_THEME_COLOR = color;
+        window.__PL_CURRENT_THEME_APPEARANCE = mode;
+      })();
+    </script>
     <link rel="preload" href="/src/output-v168.css" as="style" />
 
     <link rel="stylesheet" href="/src/output-v168.css" />

--- a/index.html
+++ b/index.html
@@ -3,16 +3,23 @@
   <head>
     <script>
       (() => {
+        const themeColors = {
+          light: "#faf9f9",
+          dark: "#0f0f0f",
+        };
+        window.__PL_THEME_COLORS = themeColors;
+
         const theme = localStorage.theme || "system";
-        if (
-          theme === "dark" ||
-          (theme === "system" &&
-            window.matchMedia("(prefers-color-scheme: dark)").matches)
-        ) {
-          document.documentElement.classList.add("dark");
-        } else {
-          document.documentElement.classList.remove("dark");
-        }
+        const prefersDark = window
+          .matchMedia("(prefers-color-scheme: dark)")
+          .matches;
+        const useDark =
+          theme === "dark" || (theme === "system" && prefersDark);
+
+        document.documentElement.classList.toggle("dark", useDark);
+        window.__PL_INITIAL_THEME = useDark ? "dark" : "light";
+        window.__PL_ACTIVE_THEME_COLOR =
+          themeColors[useDark ? "dark" : "light"];
       })();
     </script>
     <script>
@@ -59,7 +66,59 @@
     <link rel="manifest" href="/site.webmanifest" />
     <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5" />
     <meta name="msapplication-TileColor" content="#da532c" />
-    <meta name="theme-color" content="#ffffff" />
+    <meta
+      name="theme-color"
+      content="#faf9f9"
+      media="(prefers-color-scheme: light)"
+      data-theme-control="color"
+    />
+    <meta
+      name="theme-color"
+      content="#0f0f0f"
+      media="(prefers-color-scheme: dark)"
+      data-theme-control="color"
+    />
+    <meta name="theme-color" content="#faf9f9" data-theme-control="color" />
+    <meta
+      name="msapplication-navbutton-color"
+      content="#faf9f9"
+      data-theme-control="color"
+    />
+    <meta
+      name="apple-mobile-web-app-status-bar-style"
+      content="default"
+      data-theme-control="status"
+    />
+    <script>
+      (() => {
+        const themeColors = window.__PL_THEME_COLORS || {
+          light: "#faf9f9",
+          dark: "#0f0f0f",
+        };
+        const mode =
+          window.__PL_INITIAL_THEME ||
+          (document.documentElement.classList.contains("dark")
+            ? "dark"
+            : "light");
+        const color = themeColors[mode] || themeColors.light;
+
+        document
+          .querySelectorAll('meta[data-theme-control="color"]')
+          .forEach((meta) => {
+            meta.setAttribute("content", color);
+          });
+
+        const statusMeta = document.querySelector(
+          'meta[data-theme-control="status"]'
+        );
+        if (statusMeta) {
+          statusMeta.setAttribute("content", mode === "dark" ? "black" : "default");
+        }
+
+        window.__PL_ACTIVE_THEME_COLOR = color;
+        window.__PL_CURRENT_THEME_APPEARANCE = mode;
+      })();
+    </script>
     <link rel="canonical" href="https://pierrelouis.net/" />
     <link
       rel="preload"

--- a/links/index.html
+++ b/links/index.html
@@ -3,16 +3,23 @@
   <head>
     <script>
       (() => {
+        const themeColors = {
+          light: "#faf9f9",
+          dark: "#0f0f0f",
+        };
+        window.__PL_THEME_COLORS = themeColors;
+
         const theme = localStorage.theme || "system";
-        if (
-          theme === "dark" ||
-          (theme === "system" &&
-            window.matchMedia("(prefers-color-scheme: dark)").matches)
-        ) {
-          document.documentElement.classList.add("dark");
-        } else {
-          document.documentElement.classList.remove("dark");
-        }
+        const prefersDark = window
+          .matchMedia("(prefers-color-scheme: dark)")
+          .matches;
+        const useDark =
+          theme === "dark" || (theme === "system" && prefersDark);
+
+        document.documentElement.classList.toggle("dark", useDark);
+        window.__PL_INITIAL_THEME = useDark ? "dark" : "light";
+        window.__PL_ACTIVE_THEME_COLOR =
+          themeColors[useDark ? "dark" : "light"];
       })();
     </script>
     <script>
@@ -58,7 +65,59 @@
     <link rel="manifest" href="/site.webmanifest" />
     <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5" />
     <meta name="msapplication-TileColor" content="#da532c" />
-    <meta name="theme-color" content="#ffffff" />
+    <meta
+      name="theme-color"
+      content="#faf9f9"
+      media="(prefers-color-scheme: light)"
+      data-theme-control="color"
+    />
+    <meta
+      name="theme-color"
+      content="#0f0f0f"
+      media="(prefers-color-scheme: dark)"
+      data-theme-control="color"
+    />
+    <meta name="theme-color" content="#faf9f9" data-theme-control="color" />
+    <meta
+      name="msapplication-navbutton-color"
+      content="#faf9f9"
+      data-theme-control="color"
+    />
+    <meta
+      name="apple-mobile-web-app-status-bar-style"
+      content="default"
+      data-theme-control="status"
+    />
+    <script>
+      (() => {
+        const themeColors = window.__PL_THEME_COLORS || {
+          light: "#faf9f9",
+          dark: "#0f0f0f",
+        };
+        const mode =
+          window.__PL_INITIAL_THEME ||
+          (document.documentElement.classList.contains("dark")
+            ? "dark"
+            : "light");
+        const color = themeColors[mode] || themeColors.light;
+
+        document
+          .querySelectorAll('meta[data-theme-control="color"]')
+          .forEach((meta) => {
+            meta.setAttribute("content", color);
+          });
+
+        const statusMeta = document.querySelector(
+          'meta[data-theme-control="status"]'
+        );
+        if (statusMeta) {
+          statusMeta.setAttribute("content", mode === "dark" ? "black" : "default");
+        }
+
+        window.__PL_ACTIVE_THEME_COLOR = color;
+        window.__PL_CURRENT_THEME_APPEARANCE = mode;
+      })();
+    </script>
     <link rel="preload" href="/src/output-v168.css" as="style" />
 
     <link rel="stylesheet" href="/src/output-v168.css" />

--- a/now/index.html
+++ b/now/index.html
@@ -3,16 +3,23 @@
   <head>
     <script>
       (() => {
+        const themeColors = {
+          light: "#faf9f9",
+          dark: "#0f0f0f",
+        };
+        window.__PL_THEME_COLORS = themeColors;
+
         const theme = localStorage.theme || "system";
-        if (
-          theme === "dark" ||
-          (theme === "system" &&
-            window.matchMedia("(prefers-color-scheme: dark)").matches)
-        ) {
-          document.documentElement.classList.add("dark");
-        } else {
-          document.documentElement.classList.remove("dark");
-        }
+        const prefersDark = window
+          .matchMedia("(prefers-color-scheme: dark)")
+          .matches;
+        const useDark =
+          theme === "dark" || (theme === "system" && prefersDark);
+
+        document.documentElement.classList.toggle("dark", useDark);
+        window.__PL_INITIAL_THEME = useDark ? "dark" : "light";
+        window.__PL_ACTIVE_THEME_COLOR =
+          themeColors[useDark ? "dark" : "light"];
       })();
     </script>
     <script>
@@ -58,7 +65,59 @@
     <link rel="manifest" href="/site.webmanifest" />
     <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5" />
     <meta name="msapplication-TileColor" content="#da532c" />
-    <meta name="theme-color" content="#ffffff" />
+    <meta
+      name="theme-color"
+      content="#faf9f9"
+      media="(prefers-color-scheme: light)"
+      data-theme-control="color"
+    />
+    <meta
+      name="theme-color"
+      content="#0f0f0f"
+      media="(prefers-color-scheme: dark)"
+      data-theme-control="color"
+    />
+    <meta name="theme-color" content="#faf9f9" data-theme-control="color" />
+    <meta
+      name="msapplication-navbutton-color"
+      content="#faf9f9"
+      data-theme-control="color"
+    />
+    <meta
+      name="apple-mobile-web-app-status-bar-style"
+      content="default"
+      data-theme-control="status"
+    />
+    <script>
+      (() => {
+        const themeColors = window.__PL_THEME_COLORS || {
+          light: "#faf9f9",
+          dark: "#0f0f0f",
+        };
+        const mode =
+          window.__PL_INITIAL_THEME ||
+          (document.documentElement.classList.contains("dark")
+            ? "dark"
+            : "light");
+        const color = themeColors[mode] || themeColors.light;
+
+        document
+          .querySelectorAll('meta[data-theme-control="color"]')
+          .forEach((meta) => {
+            meta.setAttribute("content", color);
+          });
+
+        const statusMeta = document.querySelector(
+          'meta[data-theme-control="status"]'
+        );
+        if (statusMeta) {
+          statusMeta.setAttribute("content", mode === "dark" ? "black" : "default");
+        }
+
+        window.__PL_ACTIVE_THEME_COLOR = color;
+        window.__PL_CURRENT_THEME_APPEARANCE = mode;
+      })();
+    </script>
     <link rel="preload" href="/src/output-v168.css" as="style" />
     <link rel="stylesheet" href="/src/output-v168.css" />
 

--- a/posts/experiments/animated-avatar.html
+++ b/posts/experiments/animated-avatar.html
@@ -3,16 +3,23 @@
   <head>
     <script>
       (() => {
+        const themeColors = {
+          light: "#faf9f9",
+          dark: "#0f0f0f",
+        };
+        window.__PL_THEME_COLORS = themeColors;
+
         const theme = localStorage.theme || "system";
-        if (
-          theme === "dark" ||
-          (theme === "system" &&
-            window.matchMedia("(prefers-color-scheme: dark)").matches)
-        ) {
-          document.documentElement.classList.add("dark");
-        } else {
-          document.documentElement.classList.remove("dark");
-        }
+        const prefersDark = window
+          .matchMedia("(prefers-color-scheme: dark)")
+          .matches;
+        const useDark =
+          theme === "dark" || (theme === "system" && prefersDark);
+
+        document.documentElement.classList.toggle("dark", useDark);
+        window.__PL_INITIAL_THEME = useDark ? "dark" : "light";
+        window.__PL_ACTIVE_THEME_COLOR =
+          themeColors[useDark ? "dark" : "light"];
       })();
     </script>
     <script>
@@ -58,7 +65,59 @@
     <link rel="manifest" href="/site.webmanifest" />
     <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5" />
     <meta name="msapplication-TileColor" content="#da532c" />
-    <meta name="theme-color" content="#ffffff" />
+    <meta
+      name="theme-color"
+      content="#faf9f9"
+      media="(prefers-color-scheme: light)"
+      data-theme-control="color"
+    />
+    <meta
+      name="theme-color"
+      content="#0f0f0f"
+      media="(prefers-color-scheme: dark)"
+      data-theme-control="color"
+    />
+    <meta name="theme-color" content="#faf9f9" data-theme-control="color" />
+    <meta
+      name="msapplication-navbutton-color"
+      content="#faf9f9"
+      data-theme-control="color"
+    />
+    <meta
+      name="apple-mobile-web-app-status-bar-style"
+      content="default"
+      data-theme-control="status"
+    />
+    <script>
+      (() => {
+        const themeColors = window.__PL_THEME_COLORS || {
+          light: "#faf9f9",
+          dark: "#0f0f0f",
+        };
+        const mode =
+          window.__PL_INITIAL_THEME ||
+          (document.documentElement.classList.contains("dark")
+            ? "dark"
+            : "light");
+        const color = themeColors[mode] || themeColors.light;
+
+        document
+          .querySelectorAll('meta[data-theme-control="color"]')
+          .forEach((meta) => {
+            meta.setAttribute("content", color);
+          });
+
+        const statusMeta = document.querySelector(
+          'meta[data-theme-control="status"]'
+        );
+        if (statusMeta) {
+          statusMeta.setAttribute("content", mode === "dark" ? "black" : "default");
+        }
+
+        window.__PL_ACTIVE_THEME_COLOR = color;
+        window.__PL_CURRENT_THEME_APPEARANCE = mode;
+      })();
+    </script>
     <link rel="preload" href="/src/output-v168.css" as="style" />
 
     <link rel="stylesheet" href="/src/output-v168.css" />

--- a/posts/experiments/interactive-pixel-grid.html
+++ b/posts/experiments/interactive-pixel-grid.html
@@ -3,16 +3,23 @@
   <head>
     <script>
       (() => {
+        const themeColors = {
+          light: "#faf9f9",
+          dark: "#0f0f0f",
+        };
+        window.__PL_THEME_COLORS = themeColors;
+
         const theme = localStorage.theme || "system";
-        if (
-          theme === "dark" ||
-          (theme === "system" &&
-            window.matchMedia("(prefers-color-scheme: dark)").matches)
-        ) {
-          document.documentElement.classList.add("dark");
-        } else {
-          document.documentElement.classList.remove("dark");
-        }
+        const prefersDark = window
+          .matchMedia("(prefers-color-scheme: dark)")
+          .matches;
+        const useDark =
+          theme === "dark" || (theme === "system" && prefersDark);
+
+        document.documentElement.classList.toggle("dark", useDark);
+        window.__PL_INITIAL_THEME = useDark ? "dark" : "light";
+        window.__PL_ACTIVE_THEME_COLOR =
+          themeColors[useDark ? "dark" : "light"];
       })();
     </script>
     <script>
@@ -58,7 +65,59 @@
     <link rel="manifest" href="/site.webmanifest" />
     <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5" />
     <meta name="msapplication-TileColor" content="#da532c" />
-    <meta name="theme-color" content="#ffffff" />
+    <meta
+      name="theme-color"
+      content="#faf9f9"
+      media="(prefers-color-scheme: light)"
+      data-theme-control="color"
+    />
+    <meta
+      name="theme-color"
+      content="#0f0f0f"
+      media="(prefers-color-scheme: dark)"
+      data-theme-control="color"
+    />
+    <meta name="theme-color" content="#faf9f9" data-theme-control="color" />
+    <meta
+      name="msapplication-navbutton-color"
+      content="#faf9f9"
+      data-theme-control="color"
+    />
+    <meta
+      name="apple-mobile-web-app-status-bar-style"
+      content="default"
+      data-theme-control="status"
+    />
+    <script>
+      (() => {
+        const themeColors = window.__PL_THEME_COLORS || {
+          light: "#faf9f9",
+          dark: "#0f0f0f",
+        };
+        const mode =
+          window.__PL_INITIAL_THEME ||
+          (document.documentElement.classList.contains("dark")
+            ? "dark"
+            : "light");
+        const color = themeColors[mode] || themeColors.light;
+
+        document
+          .querySelectorAll('meta[data-theme-control="color"]')
+          .forEach((meta) => {
+            meta.setAttribute("content", color);
+          });
+
+        const statusMeta = document.querySelector(
+          'meta[data-theme-control="status"]'
+        );
+        if (statusMeta) {
+          statusMeta.setAttribute("content", mode === "dark" ? "black" : "default");
+        }
+
+        window.__PL_ACTIVE_THEME_COLOR = color;
+        window.__PL_CURRENT_THEME_APPEARANCE = mode;
+      })();
+    </script>
     <link rel="preload" href="/src/output-v168.css" as="style" />
 
     <link rel="stylesheet" href="/src/output-v168.css" />

--- a/posts/index.html
+++ b/posts/index.html
@@ -3,16 +3,23 @@
   <head>
     <script>
       (() => {
+        const themeColors = {
+          light: "#faf9f9",
+          dark: "#0f0f0f",
+        };
+        window.__PL_THEME_COLORS = themeColors;
+
         const theme = localStorage.theme || "system";
-        if (
-          theme === "dark" ||
-          (theme === "system" &&
-            window.matchMedia("(prefers-color-scheme: dark)").matches)
-        ) {
-          document.documentElement.classList.add("dark");
-        } else {
-          document.documentElement.classList.remove("dark");
-        }
+        const prefersDark = window
+          .matchMedia("(prefers-color-scheme: dark)")
+          .matches;
+        const useDark =
+          theme === "dark" || (theme === "system" && prefersDark);
+
+        document.documentElement.classList.toggle("dark", useDark);
+        window.__PL_INITIAL_THEME = useDark ? "dark" : "light";
+        window.__PL_ACTIVE_THEME_COLOR =
+          themeColors[useDark ? "dark" : "light"];
       })();
     </script>
     <script>
@@ -58,7 +65,59 @@
     <link rel="manifest" href="/site.webmanifest" />
     <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5" />
     <meta name="msapplication-TileColor" content="#da532c" />
-    <meta name="theme-color" content="#ffffff" />
+    <meta
+      name="theme-color"
+      content="#faf9f9"
+      media="(prefers-color-scheme: light)"
+      data-theme-control="color"
+    />
+    <meta
+      name="theme-color"
+      content="#0f0f0f"
+      media="(prefers-color-scheme: dark)"
+      data-theme-control="color"
+    />
+    <meta name="theme-color" content="#faf9f9" data-theme-control="color" />
+    <meta
+      name="msapplication-navbutton-color"
+      content="#faf9f9"
+      data-theme-control="color"
+    />
+    <meta
+      name="apple-mobile-web-app-status-bar-style"
+      content="default"
+      data-theme-control="status"
+    />
+    <script>
+      (() => {
+        const themeColors = window.__PL_THEME_COLORS || {
+          light: "#faf9f9",
+          dark: "#0f0f0f",
+        };
+        const mode =
+          window.__PL_INITIAL_THEME ||
+          (document.documentElement.classList.contains("dark")
+            ? "dark"
+            : "light");
+        const color = themeColors[mode] || themeColors.light;
+
+        document
+          .querySelectorAll('meta[data-theme-control="color"]')
+          .forEach((meta) => {
+            meta.setAttribute("content", color);
+          });
+
+        const statusMeta = document.querySelector(
+          'meta[data-theme-control="status"]'
+        );
+        if (statusMeta) {
+          statusMeta.setAttribute("content", mode === "dark" ? "black" : "default");
+        }
+
+        window.__PL_ACTIVE_THEME_COLOR = color;
+        window.__PL_CURRENT_THEME_APPEARANCE = mode;
+      })();
+    </script>
     <link rel="preload" href="/src/output-v168.css" as="style" />
 
     <link rel="stylesheet" href="/src/output-v168.css" />

--- a/projects/index.html
+++ b/projects/index.html
@@ -3,16 +3,23 @@
   <head>
     <script>
       (() => {
+        const themeColors = {
+          light: "#faf9f9",
+          dark: "#0f0f0f",
+        };
+        window.__PL_THEME_COLORS = themeColors;
+
         const theme = localStorage.theme || "system";
-        if (
-          theme === "dark" ||
-          (theme === "system" &&
-            window.matchMedia("(prefers-color-scheme: dark)").matches)
-        ) {
-          document.documentElement.classList.add("dark");
-        } else {
-          document.documentElement.classList.remove("dark");
-        }
+        const prefersDark = window
+          .matchMedia("(prefers-color-scheme: dark)")
+          .matches;
+        const useDark =
+          theme === "dark" || (theme === "system" && prefersDark);
+
+        document.documentElement.classList.toggle("dark", useDark);
+        window.__PL_INITIAL_THEME = useDark ? "dark" : "light";
+        window.__PL_ACTIVE_THEME_COLOR =
+          themeColors[useDark ? "dark" : "light"];
       })();
     </script>
     <script>
@@ -58,7 +65,59 @@
     <link rel="manifest" href="/site.webmanifest" />
     <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5" />
     <meta name="msapplication-TileColor" content="#da532c" />
-    <meta name="theme-color" content="#ffffff" />
+    <meta
+      name="theme-color"
+      content="#faf9f9"
+      media="(prefers-color-scheme: light)"
+      data-theme-control="color"
+    />
+    <meta
+      name="theme-color"
+      content="#0f0f0f"
+      media="(prefers-color-scheme: dark)"
+      data-theme-control="color"
+    />
+    <meta name="theme-color" content="#faf9f9" data-theme-control="color" />
+    <meta
+      name="msapplication-navbutton-color"
+      content="#faf9f9"
+      data-theme-control="color"
+    />
+    <meta
+      name="apple-mobile-web-app-status-bar-style"
+      content="default"
+      data-theme-control="status"
+    />
+    <script>
+      (() => {
+        const themeColors = window.__PL_THEME_COLORS || {
+          light: "#faf9f9",
+          dark: "#0f0f0f",
+        };
+        const mode =
+          window.__PL_INITIAL_THEME ||
+          (document.documentElement.classList.contains("dark")
+            ? "dark"
+            : "light");
+        const color = themeColors[mode] || themeColors.light;
+
+        document
+          .querySelectorAll('meta[data-theme-control="color"]')
+          .forEach((meta) => {
+            meta.setAttribute("content", color);
+          });
+
+        const statusMeta = document.querySelector(
+          'meta[data-theme-control="status"]'
+        );
+        if (statusMeta) {
+          statusMeta.setAttribute("content", mode === "dark" ? "black" : "default");
+        }
+
+        window.__PL_ACTIVE_THEME_COLOR = color;
+        window.__PL_CURRENT_THEME_APPEARANCE = mode;
+      })();
+    </script>
     <link rel="preload" href="/src/output-v168.css" as="style" />
 
     <link rel="stylesheet" href="/src/output-v168.css" />

--- a/scripts/page-skeleton.html
+++ b/scripts/page-skeleton.html
@@ -3,16 +3,23 @@
   <head>
     <script>
       (() => {
+        const themeColors = {
+          light: "#faf9f9",
+          dark: "#0f0f0f",
+        };
+        window.__PL_THEME_COLORS = themeColors;
+
         const theme = localStorage.theme || "system";
-        if (
-          theme === "dark" ||
-          (theme === "system" &&
-            window.matchMedia("(prefers-color-scheme: dark)").matches)
-        ) {
-          document.documentElement.classList.add("dark");
-        } else {
-          document.documentElement.classList.remove("dark");
-        }
+        const prefersDark = window
+          .matchMedia("(prefers-color-scheme: dark)")
+          .matches;
+        const useDark =
+          theme === "dark" || (theme === "system" && prefersDark);
+
+        document.documentElement.classList.toggle("dark", useDark);
+        window.__PL_INITIAL_THEME = useDark ? "dark" : "light";
+        window.__PL_ACTIVE_THEME_COLOR =
+          themeColors[useDark ? "dark" : "light"];
       })();
     </script>
     <script>
@@ -58,7 +65,59 @@
     <link rel="manifest" href="/site.webmanifest" />
     <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5" />
     <meta name="msapplication-TileColor" content="#da532c" />
-    <meta name="theme-color" content="#ffffff" />
+    <meta
+      name="theme-color"
+      content="#faf9f9"
+      media="(prefers-color-scheme: light)"
+      data-theme-control="color"
+    />
+    <meta
+      name="theme-color"
+      content="#0f0f0f"
+      media="(prefers-color-scheme: dark)"
+      data-theme-control="color"
+    />
+    <meta name="theme-color" content="#faf9f9" data-theme-control="color" />
+    <meta
+      name="msapplication-navbutton-color"
+      content="#faf9f9"
+      data-theme-control="color"
+    />
+    <meta
+      name="apple-mobile-web-app-status-bar-style"
+      content="default"
+      data-theme-control="status"
+    />
+    <script>
+      (() => {
+        const themeColors = window.__PL_THEME_COLORS || {
+          light: "#faf9f9",
+          dark: "#0f0f0f",
+        };
+        const mode =
+          window.__PL_INITIAL_THEME ||
+          (document.documentElement.classList.contains("dark")
+            ? "dark"
+            : "light");
+        const color = themeColors[mode] || themeColors.light;
+
+        document
+          .querySelectorAll('meta[data-theme-control="color"]')
+          .forEach((meta) => {
+            meta.setAttribute("content", color);
+          });
+
+        const statusMeta = document.querySelector(
+          'meta[data-theme-control="status"]'
+        );
+        if (statusMeta) {
+          statusMeta.setAttribute("content", mode === "dark" ? "black" : "default");
+        }
+
+        window.__PL_ACTIVE_THEME_COLOR = color;
+        window.__PL_CURRENT_THEME_APPEARANCE = mode;
+      })();
+    </script>
     <link rel="preload" href="/src/output-v168.css" as="style" />
 
     <link rel="stylesheet" href="/src/output-v168.css" />

--- a/uses/index.html
+++ b/uses/index.html
@@ -3,16 +3,23 @@
   <head>
     <script>
       (() => {
+        const themeColors = {
+          light: "#faf9f9",
+          dark: "#0f0f0f",
+        };
+        window.__PL_THEME_COLORS = themeColors;
+
         const theme = localStorage.theme || "system";
-        if (
-          theme === "dark" ||
-          (theme === "system" &&
-            window.matchMedia("(prefers-color-scheme: dark)").matches)
-        ) {
-          document.documentElement.classList.add("dark");
-        } else {
-          document.documentElement.classList.remove("dark");
-        }
+        const prefersDark = window
+          .matchMedia("(prefers-color-scheme: dark)")
+          .matches;
+        const useDark =
+          theme === "dark" || (theme === "system" && prefersDark);
+
+        document.documentElement.classList.toggle("dark", useDark);
+        window.__PL_INITIAL_THEME = useDark ? "dark" : "light";
+        window.__PL_ACTIVE_THEME_COLOR =
+          themeColors[useDark ? "dark" : "light"];
       })();
     </script>
     <script>
@@ -58,7 +65,59 @@
     <link rel="manifest" href="/site.webmanifest" />
     <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5" />
     <meta name="msapplication-TileColor" content="#da532c" />
-    <meta name="theme-color" content="#ffffff" />
+    <meta
+      name="theme-color"
+      content="#faf9f9"
+      media="(prefers-color-scheme: light)"
+      data-theme-control="color"
+    />
+    <meta
+      name="theme-color"
+      content="#0f0f0f"
+      media="(prefers-color-scheme: dark)"
+      data-theme-control="color"
+    />
+    <meta name="theme-color" content="#faf9f9" data-theme-control="color" />
+    <meta
+      name="msapplication-navbutton-color"
+      content="#faf9f9"
+      data-theme-control="color"
+    />
+    <meta
+      name="apple-mobile-web-app-status-bar-style"
+      content="default"
+      data-theme-control="status"
+    />
+    <script>
+      (() => {
+        const themeColors = window.__PL_THEME_COLORS || {
+          light: "#faf9f9",
+          dark: "#0f0f0f",
+        };
+        const mode =
+          window.__PL_INITIAL_THEME ||
+          (document.documentElement.classList.contains("dark")
+            ? "dark"
+            : "light");
+        const color = themeColors[mode] || themeColors.light;
+
+        document
+          .querySelectorAll('meta[data-theme-control="color"]')
+          .forEach((meta) => {
+            meta.setAttribute("content", color);
+          });
+
+        const statusMeta = document.querySelector(
+          'meta[data-theme-control="status"]'
+        );
+        if (statusMeta) {
+          statusMeta.setAttribute("content", mode === "dark" ? "black" : "default");
+        }
+
+        window.__PL_ACTIVE_THEME_COLOR = color;
+        window.__PL_CURRENT_THEME_APPEARANCE = mode;
+      })();
+    </script>
     <link rel="preload" href="/src/output-v168.css" as="style" />
 
     <link rel="stylesheet" href="/src/output-v168.css" />


### PR DESCRIPTION
## Summary
- add helper utilities to compute theme colors and update metadata whenever the active theme changes
- update every page head (and the shared skeleton) with theme-aware meta tags plus an inline bootstrap that syncs browser UI colors on load

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce839815608332b16d8b48933af6a7